### PR TITLE
Drop Serenity crate in favor of Discord crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 **/*.rs.bk
+/.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,20 +1,7 @@
-[root]
-name = "technobot"
-version = "0.1.0"
-dependencies = [
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "scraper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serenity 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+[[package]]
+name = "adler32"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "advapi32-sys"
@@ -86,6 +73,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "build_const"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +135,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "crc"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crc-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crypt32-sys"
@@ -410,6 +416,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "idna"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +481,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libflate"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log"
@@ -524,6 +554,17 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime_guess"
+version = "2.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mime 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -802,6 +843,29 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "reqwest"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 2.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1009,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serenity"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1114,22 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "technobot"
+version = "0.1.0"
+dependencies = [
+ "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scraper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serenity 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1216,17 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1274,6 +1376,7 @@ dependencies = [
 ]
 
 [metadata]
+"checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
@@ -1283,6 +1386,7 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5cde24d1b2e2216a726368b2363a273739c91f4e3eb4e0dd12d672d396ad989"
+"checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
 "checksum cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7db2f146208d7e0fbee761b09cd65a7f51ccc38705d4e7262dad4d73b12a76b1"
@@ -1291,6 +1395,8 @@ dependencies = [
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
+"checksum crc 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fba69ea0e15e720f7e1cfe1cf3bc55007fbd41e32b8ae11cfa343e7e5961e79a"
+"checksum crc-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "003d1170779d405378223470f5864b41b79a91969be1260e4de7b4ec069af69c"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum cssparser 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9447212c775f9e07f598fc5263fac48c7cea7a1c236646e4c9eb6070f13a85fd"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
@@ -1320,6 +1426,7 @@ dependencies = [
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum hyper 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "641abc3e3fcf0de41165595f801376e01106bca1fd876dda937730e477ca004c"
 "checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"
+"checksum hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c81fa95203e2a6087242c38691a0210f23e9f3f8f944350bd676522132e2985"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
@@ -1328,6 +1435,7 @@ dependencies = [
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
 "checksum libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d1419b2939a0bc44b77feb34661583c7546b532b192feab36249ab584b86856c"
+"checksum libflate 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ae46bcdafa496981e996e57c5be82c0a7f130a071323764c6faa4803619f1e67"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
@@ -1337,6 +1445,7 @@ dependencies = [
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e3d709ffbb330e1566dc2f2a3c9b58a5ad4a381f740b810cd305dc3f089bc160"
 "checksum mime_guess 1.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bbee1a836f344ac39d4a59bfe7be2bd3150353ff71678afb740216f8270b333e"
+"checksum mime_guess 2.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27a5e6679a0614e25adc14c6434ba84e41632b765a6d9cb2031a0cca682699ae"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "dbd91d3bfbceb13897065e97b2ef177a09a438cb33612b2d371bf568819a9313"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
@@ -1367,6 +1476,7 @@ dependencies = [
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
+"checksum reqwest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "194fe0d39dea7f89738707bf70e9f3ed47e8aca47d4b2eeaad6ac7831d2d390b"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
@@ -1384,6 +1494,7 @@ dependencies = [
 "checksum serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1afcaae083fd1c46952a315062326bc9957f182358eb7da03b57ef1c688f7aa9"
 "checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
 "checksum serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d243424e06f9f9c39e3cd36147470fd340db785825e367625f79298a6ac6b7ac"
+"checksum serde_urlencoded 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce0fd303af908732989354c6f02e05e2e6d597152870f2c6990efb0577137480"
 "checksum serenity 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a597303170735b79f47b9b261524a8730785af266808f2efc98ad2c1677629df"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
@@ -1404,6 +1515,7 @@ dependencies = [
 "checksum tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ab83e7adb5677e42e405fa4ceff75659d93c4d7d7dd22f52fcec59ee9f02af"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
+"checksum tokio-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d88e411cac1c87e405e4090be004493c5d8072a370661033b1a64ea205ec2e13"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,11 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "antidote"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "backtrace"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +53,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,13 +68,13 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "bitflags"
-version = "1.0.0"
+name = "build_const"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "build_const"
-version = "0.2.0"
+name = "byteorder"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -107,7 +107,6 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -117,6 +116,17 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cookie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,6 +210,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "discord"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64-rs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multipart 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opus 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sodiumoxide 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +237,11 @@ dependencies = [
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "dtoa"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dtoa"
@@ -285,25 +319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "evzht9h3nznqzwl"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "flate2"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +361,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcc"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gdi32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hpack"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,17 +404,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.10.13"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -403,16 +444,6 @@ dependencies = [
  "tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hyper-native-tls"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -447,6 +478,11 @@ dependencies = [
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itoa"
@@ -490,6 +526,23 @@ dependencies = [
  "adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libressl-pnacl-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pnacl-build-helper 1.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libsodium-sys"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -610,15 +663,14 @@ dependencies = [
 
 [[package]]
 name = "multipart"
-version = "0.13.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 1.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -652,6 +704,14 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -701,6 +761,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys-extras 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
 version = "0.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -709,6 +782,18 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -723,32 +808,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "owning_ref"
-version = "0.3.3"
+name = "openssl-sys-extras"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-verify"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "opus"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opus-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "opus-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -795,6 +887,15 @@ dependencies = [
 name = "pkg-config"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pnacl-build-helper"
+version = "1.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "quickersort"
@@ -887,6 +988,15 @@ dependencies = [
 name = "safemem"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "schannel"
@@ -999,6 +1109,17 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1018,35 +1139,6 @@ dependencies = [
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "serenity"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "evzht9h3nznqzwl 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "multipart 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_shift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sha1"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "siphasher"
@@ -1069,14 +1161,22 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "smallvec"
-version = "0.4.3"
+name = "sodiumoxide"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsodium-sys 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.0.0"
+name = "solicit"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "string_cache"
@@ -1118,7 +1218,9 @@ name = "technobot"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "discord 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1126,7 +1228,6 @@ dependencies = [
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serenity 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1231,21 +1332,13 @@ dependencies = [
 
 [[package]]
 name = "traitobject"
-version = "0.1.0"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "typeable"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "unicase"
@@ -1298,14 +1391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "url"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1398,15 @@ dependencies = [
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "user32-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1342,11 +1436,6 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "vec_shift"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "version_check"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1444,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "websocket"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -1379,20 +1494,21 @@ dependencies = [
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
-"checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
+"checksum base64-rs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c7371d60e477f20993c1f9b95e0cf22dca90d953e2e1d3d4f9c9e578765c060"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-"checksum bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5cde24d1b2e2216a726368b2363a273739c91f4e3eb4e0dd12d672d396ad989"
 "checksum build_const 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e90dc84f5e62d2ebe7676b83c22d33b6db8bd27340fb6ffbff0a364efa0cb9c9"
+"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
 "checksum cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7db2f146208d7e0fbee761b09cd65a7f51ccc38705d4e7262dad4d73b12a76b1"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+"checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crc 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fba69ea0e15e720f7e1cfe1cf3bc55007fbd41e32b8ae11cfa343e7e5961e79a"
@@ -1403,7 +1519,9 @@ dependencies = [
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
 "checksum derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9ca9ade651388daad7c993f005d0d20c4f6fe78c1cdc93e95f161c6f5ede4a"
+"checksum discord 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "614a5375ce9ca21bf61478d51fd1eb436cbafb79229c27ce0dbe2b4eee95abf4"
 "checksum dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d6f0e2bb24d163428d8031d3ebd2d2bd903ad933205a97d0f18c7c1aade380f3"
+"checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum ego-tree 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf94c44c4d72ff9a371d5f8143a6c12adf0d6a0e52b2ae5246d648ffeac9ac4d"
 "checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
@@ -1414,21 +1532,23 @@ dependencies = [
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
-"checksum evzht9h3nznqzwl 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe99a076e5aa6cfa5949bfec1cf8963cf22c81455a2f38f33789c691200259b5"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
 "checksum futf 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "51f93f3de6ba1794dcd5810b3546d004600a59a98266487c8407bc4b24e398f3"
 "checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
 "checksum futures-cpupool 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "77d49e7de8b91b20d6fda43eea906637eff18b96702eb6b2872df8bfab1ad2b5"
+"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
+"checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"
 "checksum html5ever 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fd04d31858b8fd8ac9d55570da8c822bc6defd2c1ac18a47cb70fc280f42b432"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
-"checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum hyper 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "641abc3e3fcf0de41165595f801376e01106bca1fd876dda937730e477ca004c"
-"checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"
+"checksum hyper 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)" = "1b9bf64f730d6ee4b0528a5f0a316363da9d8104318731509d4ccc86248f82b3"
 "checksum hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c81fa95203e2a6087242c38691a0210f23e9f3f8f944350bd676522132e2985"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
+"checksum itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3088ea4baeceb0284ee9eea42f591226e6beaecf65373e41b38d95a1b8e7a1"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
@@ -1436,6 +1556,8 @@ dependencies = [
 "checksum lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
 "checksum libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d1419b2939a0bc44b77feb34661583c7546b532b192feab36249ab584b86856c"
 "checksum libflate 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ae46bcdafa496981e996e57c5be82c0a7f130a071323764c6faa4803619f1e67"
+"checksum libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc058951ab6a3ef35ca16462d7642c4867e6403520811f28537a4e2f2db3e71"
+"checksum libsodium-sys 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "44e9986c330611ccd26ea74e502c70e5ebab2874c4c23f2f5f3c5a6ed3fbfbc6"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
@@ -1449,27 +1571,32 @@ dependencies = [
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "dbd91d3bfbceb13897065e97b2ef177a09a438cb33612b2d371bf568819a9313"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multipart 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f534489e7212a0e8fcc28c783e4686b79231c638a431c3fa46fc6cd8c3f04d20"
+"checksum multipart 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b16d6498fe5b0c2f6d973fd9753da099948834f96584d628e44a75f0d2955b03"
 "checksum native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04b781c9134a954c84f0594b9ab3f5606abc516030388e8511887ef4c204a1e5"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "52cd74cd09beba596430cc6e3091b74007169a56246e1262f0ba451ea95117b2"
+"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
 "checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
 "checksum odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "c3df9b730298cea3a1c3faa90b7e2f9df3a9c400d0936d6015e6165734eefcba"
+"checksum openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)" = "c4117b6244aac42ed0150a6019b4d953d28247c5dd6ae6f46ae469b5f2318733"
 "checksum openssl 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)" = "816914b22eb15671d62c73442a51978f311e911d6a6f6cbdafa6abce1b5038fc"
+"checksum openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)" = "89c47ee94c352eea9ddaf8e364be7f978a3bb6d66d73176572484238dd5a5c3f"
 "checksum openssl-sys 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4c63a7d559c1e5afa6d6a9e6fa34bbc5f800ffc9ae08b72c605420b0c4f5e8"
-"checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-"checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
-"checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
+"checksum openssl-sys-extras 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)" = "11c5e1dba7d3d03d80f045bf0d60111dc69213b67651e7c889527a3badabb9fa"
+"checksum openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ed86cce894f6b0ed4572e21eb34026f1dc8869cb9ee3869029131bc8c3feb2d"
+"checksum opus 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c1ea29ab439d0852a1d991c9fa8fa8e3f31aa82f938c42ed442831d08ead0db"
+"checksum opus-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fad8b294f482f7972fa466b1c64d5a564e4ee6975599d80483ee4fa83f25b6ec"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "cb325642290f28ee14d8c6201159949a872f220c62af6e110a56ea914fbe42fc"
 "checksum phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d62594c0bb54c464f633175d502038177e90309daf2e0158be42ed5f023ce88f"
 "checksum phf_generator 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6b07ffcc532ccc85e3afc45865469bf5d9e4ef5bfcf9622e3cfe80c2d275ec03"
 "checksum phf_shared 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)" = "07e24b0ca9643bdecd0632f2b3da6b1b89bbb0030e0b992afc1113b23a7bc2f2"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+"checksum pnacl-build-helper 1.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dfbe13ee77c06fb633d71c72438bd983286bb3521863a753ade8e951c7efb090"
 "checksum quickersort 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "14ae8f367c38c78abd03114e524b55a817885446662413fbca951f42848450c5"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
@@ -1481,6 +1608,7 @@ dependencies = [
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
+"checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
 "checksum schannel 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7554288337c1110e34d7a2433518d889374c1de1a45f856b7bcddb03702131fc"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum scraper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e6e16469ead09e3fd2da8aae95e5c3acc729789b59794f1f96079f3a03c2937"
@@ -1493,16 +1621,15 @@ dependencies = [
 "checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
 "checksum serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1afcaae083fd1c46952a315062326bc9957f182358eb7da03b57ef1c688f7aa9"
 "checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
+"checksum serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "67f7d2e9edc3523a9c8ec8cd6ec481b3a27810aafee3e625d311febd3e656b4c"
 "checksum serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d243424e06f9f9c39e3cd36147470fd340db785825e367625f79298a6ac6b7ac"
 "checksum serde_urlencoded 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce0fd303af908732989354c6f02e05e2e6d597152870f2c6990efb0577137480"
-"checksum serenity 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a597303170735b79f47b9b261524a8730785af266808f2efc98ad2c1677629df"
-"checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fcc8d19212aacecf95e4a7a2179b26f7aeb9732a915cf01f05b0d3e044865410"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
-"checksum smallvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fcd03faf178110ab0334d74ca9631d77f94c8c11cc77fcb59538abf0025695d"
-"checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
+"checksum sodiumoxide 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8d9da099120def269669aa349e0c3e97de4ab2c5cb9a54a765041651dd0055eb"
+"checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum string_cache 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "f585562982abf1301fa97bd2226a3c4c5712b8beb9bcd16ed72b5e96810f8657"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -1516,9 +1643,8 @@ dependencies = [
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 "checksum tokio-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d88e411cac1c87e405e4090be004493c5d8072a370661033b1a64ea205ec2e13"
-"checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+"checksum traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07eaeb7689bb7fca7ce15628319635758eda769fed481ecfe6686ddef2600616"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
-"checksum typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e01da42520092d0cd2d6ac3ae69eb21a22ad43ff195676b86f8c37f487d6b80"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
@@ -1526,15 +1652,16 @@ dependencies = [
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
 "checksum url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb819346883532a271eb626deb43c4a1bb4c4dd47c519bd78137c3e72a4fe27"
+"checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum utf-8 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9aee9ba280438b56d1ebc5329f2094f0ff457f811eeeff0b278d75aa99db400"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc7e3b898aa6f6c08e5295b6c89258d1331e9ac578cc992fb818759951bdc22"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
-"checksum vec_shift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc05c2b00a487511056141401ac10b15c0fb7422154dda53d1c610c228c3e08e"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
+"checksum websocket 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a1a6ea5ed0367f32eb3d94dcc58859ef4294b5f75ba983dbf56ac314af45d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "technobot"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -36,6 +37,29 @@ dependencies = [
 name = "antidote"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "base64"
@@ -144,11 +168,39 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "dbghelp-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "debug_unreachable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive-error-chain"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dotenv"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -217,6 +269,14 @@ dependencies = [
 name = "encoding_index_tests"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "error-chain"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "evzht9h3nznqzwl"
@@ -742,6 +802,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1277,8 @@ dependencies = [
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+"checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
+"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
@@ -1227,7 +1294,10 @@ dependencies = [
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum cssparser 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9447212c775f9e07f598fc5263fac48c7cea7a1c236646e4c9eb6070f13a85fd"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+"checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
+"checksum derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9ca9ade651388daad7c993f005d0d20c4f6fe78c1cdc93e95f161c6f5ede4a"
+"checksum dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d6f0e2bb24d163428d8031d3ebd2d2bd903ad933205a97d0f18c7c1aade380f3"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum ego-tree 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf94c44c4d72ff9a371d5f8143a6c12adf0d6a0e52b2ae5246d648ffeac9ac4d"
 "checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
@@ -1237,6 +1307,7 @@ dependencies = [
 "checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+"checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum evzht9h3nznqzwl 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe99a076e5aa6cfa5949bfec1cf8963cf22c81455a2f38f33789c691200259b5"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
@@ -1296,6 +1367,7 @@ dependencies = [
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
+"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Jacob Helwig <jacob@technosorcery.net>"]
 
 [dependencies]
 chrono = "0.4.0"
+dotenv = "0.10.1"
 futures = "*"
 hyper = "0.11.2"
 rand = "0.3.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,13 @@ authors = ["Jacob Helwig <jacob@technosorcery.net>"]
 [dependencies]
 chrono = "0.4.0"
 dotenv = "0.10.1"
-futures = "*"
-hyper = "0.11.2"
 rand = "0.3.16"
 regex = "0.2.2"
+reqwest = "0.8.0"
 scraper = "0.4.0"
 serde = "1.0.15"
 serde_derive = "1.0.15"
 serde_json = "1.0.3"
-tokio-core = "0.1"
 
 [dependencies.serenity]
 version = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Jacob Helwig <jacob@technosorcery.net>"]
 
 [dependencies]
 chrono = "0.4.0"
+discord = "0.8.0"
 dotenv = "0.10.1"
 rand = "0.3.16"
 regex = "0.2.2"
@@ -14,6 +15,6 @@ serde = "1.0.15"
 serde_derive = "1.0.15"
 serde_json = "1.0.3"
 
-[dependencies.serenity]
-version = "0.4.0"
-features = ["cache", "framework", "standard_framework"]
+[dependencies.nom]
+version = "3.2.0"
+features = ["verbose-errors"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Build & Dependencies
+
+## macOS
+
+### Dependencies
+
+```sh
+brew install pkg-config openssl libsodium opus libopusenc ffmpeg youtube-dl
+```
+
+### Compiling
+
+Unfortunately, the `openssl` crate requires some help in finding where OpenSSL
+is installed, so we need to set both `OPENSSL_INCLUDE_DIR`, and
+`DEP_OPENSSL_INCLUDE`.
+
+```sh
+OPENSSL_INCLUDE_DIR=$(brew --prefix openssl)/include DEP_OPENSSL_INCLUDE=$(brew --prefix openssl)/include cargo build
+```

--- a/env.example
+++ b/env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env for the bot to automatically pick it up when run.
+export DISCORD_TOKEN=<put your bot's discord token here>
+export TECHNOBOT_PREFIX=!

--- a/src/commands/ffxiv.rs
+++ b/src/commands/ffxiv.rs
@@ -48,42 +48,6 @@ fn next_daily_reset(now: DateTime<Utc>) -> DateTime<Utc> {
     daily_reset
 }
 
-#[test]
-fn next_daily_reset_when_before_reset_time() {
-    let now: DateTime<Utc> = DateTime::parse_from_rfc3339("2017-09-24T04:00:00-00:00")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset: DateTime<Utc> = DateTime::parse_from_rfc3339("2017-09-24T15:00:00-00:00")
-        .unwrap()
-        .with_timezone(&Utc);
-    let daily_reset = next_daily_reset(now);
-
-    assert_eq!(daily_reset,
-               expected_reset,
-               "Expected next daily reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               daily_reset);
-}
-
-#[test]
-fn next_daily_reset_when_after_reset_time() {
-    let now: DateTime<Utc> = DateTime::parse_from_rfc3339("2017-09-30T15:00:00-00:00")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset: DateTime<Utc> = DateTime::parse_from_rfc3339("2017-10-01T15:00:00-00:00")
-        .unwrap()
-        .with_timezone(&Utc);
-    let daily_reset = next_daily_reset(now);
-
-    assert_eq!(daily_reset,
-               expected_reset,
-               "Expected next daily reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               daily_reset);
-}
-
 fn next_weekly_reset(now: DateTime<Utc>) -> DateTime<Utc> {
     // Weekly reset is every Tuesday at 08:00 UTC.
     let mut weekly_reset: DateTime<Utc> = now.with_hour(8)
@@ -107,78 +71,6 @@ fn next_weekly_reset(now: DateTime<Utc>) -> DateTime<Utc> {
     }
 
     weekly_reset
-}
-
-#[test]
-fn next_weekly_reset_before_reset_time_on_tuesday() {
-    let now = DateTime::parse_from_rfc3339("2017-09-19T06:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset = DateTime::parse_from_rfc3339("2017-09-19T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let weekly_reset = next_weekly_reset(now);
-
-    assert_eq!(weekly_reset,
-               expected_reset,
-               "Expected next weekly reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               weekly_reset);
-}
-
-#[test]
-fn next_weekly_reset_after_reset_time_on_tuesday() {
-    let now = DateTime::parse_from_rfc3339("2017-09-19T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset = DateTime::parse_from_rfc3339("2017-09-26T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let weekly_reset = next_weekly_reset(now);
-
-    assert_eq!(weekly_reset,
-               expected_reset,
-               "Expected next weekly reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               weekly_reset);
-}
-
-#[test]
-fn next_weekly_reset_on_monday() {
-    let now = DateTime::parse_from_rfc3339("2017-09-18T06:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset = DateTime::parse_from_rfc3339("2017-09-19T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let weekly_reset = next_weekly_reset(now);
-
-    assert_eq!(weekly_reset,
-               expected_reset,
-               "Expected next weekly reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               weekly_reset);
-}
-
-#[test]
-fn next_weekly_reset_on_wednesday() {
-    let now = DateTime::parse_from_rfc3339("2017-09-20T06:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset = DateTime::parse_from_rfc3339("2017-09-26T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let weekly_reset = next_weekly_reset(now);
-
-    assert_eq!(weekly_reset,
-               expected_reset,
-               "Expected next weekly reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               weekly_reset);
 }
 
 fn next_crafting_reset(now: DateTime<Utc>) -> DateTime<Utc> {
@@ -206,78 +98,6 @@ fn next_crafting_reset(now: DateTime<Utc>) -> DateTime<Utc> {
     }
 
     crafting_reset
-}
-
-#[test]
-fn next_crafting_reset_before_reset_time_on_thursday() {
-    let now = DateTime::parse_from_rfc3339("2017-09-21T06:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset = DateTime::parse_from_rfc3339("2017-09-21T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let crafting_reset = next_crafting_reset(now);
-
-    assert_eq!(crafting_reset,
-               expected_reset,
-               "Expected next crafting reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               crafting_reset);
-}
-
-#[test]
-fn next_crafting_reset_after_reset_time_on_thursday() {
-    let now = DateTime::parse_from_rfc3339("2017-09-28T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset = DateTime::parse_from_rfc3339("2017-10-05T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let crafting_reset = next_crafting_reset(now);
-
-    assert_eq!(crafting_reset,
-               expected_reset,
-               "Expected next crafting reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               crafting_reset);
-}
-
-#[test]
-fn next_crafting_reset_on_wednesday() {
-    let now = DateTime::parse_from_rfc3339("2017-09-20T06:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset = DateTime::parse_from_rfc3339("2017-09-21T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let crafting_reset = next_crafting_reset(now);
-
-    assert_eq!(crafting_reset,
-               expected_reset,
-               "Expected next crafting reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               crafting_reset);
-}
-
-#[test]
-fn next_crafting_reset_on_friday() {
-    let now = DateTime::parse_from_rfc3339("2017-09-22T06:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_reset = DateTime::parse_from_rfc3339("2017-09-28T08:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let crafting_reset = next_crafting_reset(now);
-
-    assert_eq!(crafting_reset,
-               expected_reset,
-               "Expected next crafting reset from {:?} to be at {:?}. Got: {:?}",
-               now,
-               expected_reset,
-               crafting_reset);
 }
 
 fn until_string(until_duration: Duration) -> String {
@@ -328,160 +148,6 @@ fn until_string(until_duration: Duration) -> String {
     }
 
     components.join(" ")
-}
-
-#[test]
-fn until_string_with_one_week() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-10-01T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "1 week";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_multiple_weeks() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-10-08T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "2 weeks";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_one_day() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-09-25T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "1 day";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_multiple_days() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-09-26T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "2 days";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_one_hour() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-09-24T01:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "1 hour";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_multiple_hours() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-09-24T02:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "2 hours";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_one_minute() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-09-24T00:01:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "1 minute";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_multiple_minutes() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-09-24T00:02:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "2 minutes";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_multiple_components() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-10-09T15:02:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "2 weeks 1 day 15 hours 2 minutes";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_multiple_components_with_gap() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-10-09T00:02:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "2 weeks 1 day 2 minutes";
-
-    assert_eq!(until_string(duration), expected);
-}
-
-#[test]
-fn until_string_with_less_than_a_minute() {
-    let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let event = DateTime::parse_from_rfc3339("2017-09-24T00:00:30Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let duration = event.signed_duration_since(now);
-    let expected = "less than a minute";
-
-    assert_eq!(until_string(duration), expected);
 }
 
 command!(events(_ctx, msg) {
@@ -619,107 +285,446 @@ fn parse_event_json(event_json: &Vec<u8>) -> Result<FFXIVTimers, String> {
     }
 }
 
-#[test]
-fn parse_event_json_with_info() {
-    let json_to_parse = r#"{"timers":[{"name":"<a href=\"http://na.finalfantasyxiv.com/mount_campaign_2017/\">Fly the Falcon Mount Campaign</a>","type":"campaign","start":14988924E5,"end":150684114E4,"info":"Players who purchase a total of 90 days of subscription time during this time period will receive a Falcon mount."}]}"#;
-    let expected = FFXIVTimers {
-        events: vec![
-            FFXIVEvent {
-                name_html: "<a href=\"http://na.finalfantasyxiv.com/mount_campaign_2017/\">Fly the Falcon Mount Campaign</a>".to_string(),
-                kind: "campaign".to_string(),
-                start: DateTime::parse_from_rfc3339("2017-07-01T07:00:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                end: DateTime::parse_from_rfc3339("2017-10-01T06:59:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                info: Some("Players who purchase a total of 90 days of subscription time during this time period will receive a Falcon mount.".to_string())
-            }
-        ]
-    };
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let result: FFXIVTimers = parse_event_json(&json_to_parse.to_string().into_bytes()).unwrap();
+    #[test]
+    fn next_daily_reset_when_before_reset_time() {
+        let now: DateTime<Utc> = DateTime::parse_from_rfc3339("2017-09-24T04:00:00-00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset: DateTime<Utc> = DateTime::parse_from_rfc3339("2017-09-24T15:00:00-00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        let daily_reset = next_daily_reset(now);
 
-    assert_eq!(result, expected);
-}
+        assert_eq!(daily_reset,
+                   expected_reset,
+                   "Expected next daily reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   daily_reset);
+    }
 
-#[test]
-fn parse_event_json_without_info() {
-    let json_to_parse = r#"{"timers":[{"name":"<a href=\"http://na.finalfantasyxiv.com/lodestone/special/2017/The_Rising/\">The Rising</a>","type":"event rising","start":15037596E5,"end":150540114E4,"showDuration":true}]}"#;
-    let expected = FFXIVTimers {
-        events: vec![
-            FFXIVEvent {
-                name_html: "<a href=\"http://na.finalfantasyxiv.com/lodestone/special/2017/The_Rising/\">The Rising</a>".to_string(),
-                kind: "event rising".to_string(),
-                start: DateTime::parse_from_rfc3339("2017-08-26T15:00:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                end: DateTime::parse_from_rfc3339("2017-09-14T14:59:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                info: None
-            }
-        ]
-    };
+    #[test]
+    fn next_daily_reset_when_after_reset_time() {
+        let now: DateTime<Utc> = DateTime::parse_from_rfc3339("2017-09-30T15:00:00-00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset: DateTime<Utc> = DateTime::parse_from_rfc3339("2017-10-01T15:00:00-00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        let daily_reset = next_daily_reset(now);
 
-    let result: FFXIVTimers = parse_event_json(&json_to_parse.to_string().into_bytes()).unwrap();
+        assert_eq!(daily_reset,
+                   expected_reset,
+                   "Expected next daily reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   daily_reset);
+    }
 
-    assert_eq!(result, expected);
-}
+    #[test]
+    fn next_weekly_reset_before_reset_time_on_tuesday() {
+        let now = DateTime::parse_from_rfc3339("2017-09-19T06:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset = DateTime::parse_from_rfc3339("2017-09-19T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let weekly_reset = next_weekly_reset(now);
 
-#[test]
-fn parse_event_json_with_multiple_events() {
-    let json_to_parse = r#"{"timers":[{"name":"<a href=\"http://na.finalfantasyxiv.com/mount_campaign_2017/\">Fly the Falcon Mount Campaign</a>","type":"campaign","start":14988924E5,"end":150684114E4,"info":"Players who purchase a total of 90 days of subscription time during this time period will receive a Falcon mount."},{"name":"<a href=\"http://na.finalfantasyxiv.com/lodestone/special/2017/The_Rising/\">The Rising</a>","type":"event rising","start":15037596E5,"end":150540114E4,"showDuration":true},{"name":"<a href=\"https://na.finalfantasyxiv.com/lodestone/special/2017/youkai-watch/\">Yo-kai Watch</a>","type":"event yokai-watch","start":15044256E5,"end":150954834E4,"showDuration":true},{"name":"<a href=\"http://na.finalfantasyxiv.com/lodestone/news/detail/5c652e0bf15a5028c3d2762c78d9ed094c475472\">All Worlds Maintenance (Sep. 14)</a>","type":"maintenance","start":15054552E5,"end":1505466E6}]}"#;
-    let expected = FFXIVTimers {
-        events: vec![
-            FFXIVEvent {
-                name_html: "<a href=\"http://na.finalfantasyxiv.com/mount_campaign_2017/\">Fly the Falcon Mount Campaign</a>".to_string(),
-                kind: "campaign".to_string(),
-                start: DateTime::parse_from_rfc3339("2017-07-01T07:00:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                end: DateTime::parse_from_rfc3339("2017-10-01T06:59:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                info: Some("Players who purchase a total of 90 days of subscription time during this time period will receive a Falcon mount.".to_string())
-            },
-            FFXIVEvent {
-                name_html: "<a href=\"http://na.finalfantasyxiv.com/lodestone/special/2017/The_Rising/\">The Rising</a>".to_string(),
-                kind: "event rising".to_string(),
-                start: DateTime::parse_from_rfc3339("2017-08-26T15:00:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                end: DateTime::parse_from_rfc3339("2017-09-14T14:59:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                info: None
-            },
-            FFXIVEvent {
-                name_html: "<a href=\"https://na.finalfantasyxiv.com/lodestone/special/2017/youkai-watch/\">Yo-kai Watch</a>".to_string(),
-                kind: "event yokai-watch".to_string(),
-                start: DateTime::parse_from_rfc3339("2017-09-03T08:00:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                end: DateTime::parse_from_rfc3339("2017-11-01T14:59:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                info: None
-            },
-            FFXIVEvent {
-                name_html: "<a href=\"http://na.finalfantasyxiv.com/lodestone/news/detail/5c652e0bf15a5028c3d2762c78d9ed094c475472\">All Worlds Maintenance (Sep. 14)</a>".to_string(),
-                kind: "maintenance".to_string(),
-                start: DateTime::parse_from_rfc3339("2017-09-15T06:00:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                end: DateTime::parse_from_rfc3339("2017-09-15T09:00:00Z")
-                    .unwrap()
-                    .with_timezone(&Utc),
-                info: None
-            }
-        ]
-    };
+        assert_eq!(weekly_reset,
+                   expected_reset,
+                   "Expected next weekly reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   weekly_reset);
+    }
 
-    let result: FFXIVTimers = parse_event_json(&json_to_parse.to_string().into_bytes()).unwrap();
+    #[test]
+    fn next_weekly_reset_after_reset_time_on_tuesday() {
+        let now = DateTime::parse_from_rfc3339("2017-09-19T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset = DateTime::parse_from_rfc3339("2017-09-26T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let weekly_reset = next_weekly_reset(now);
 
-    assert_eq!(result, expected);
+        assert_eq!(weekly_reset,
+                   expected_reset,
+                   "Expected next weekly reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   weekly_reset);
+    }
+
+    #[test]
+    fn next_weekly_reset_on_monday() {
+        let now = DateTime::parse_from_rfc3339("2017-09-18T06:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset = DateTime::parse_from_rfc3339("2017-09-19T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let weekly_reset = next_weekly_reset(now);
+
+        assert_eq!(weekly_reset,
+                   expected_reset,
+                   "Expected next weekly reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   weekly_reset);
+    }
+
+    #[test]
+    fn next_weekly_reset_on_wednesday() {
+        let now = DateTime::parse_from_rfc3339("2017-09-20T06:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset = DateTime::parse_from_rfc3339("2017-09-26T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let weekly_reset = next_weekly_reset(now);
+
+        assert_eq!(weekly_reset,
+                   expected_reset,
+                   "Expected next weekly reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   weekly_reset);
+    }
+
+    #[test]
+    fn next_crafting_reset_before_reset_time_on_thursday() {
+        let now = DateTime::parse_from_rfc3339("2017-09-21T06:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset = DateTime::parse_from_rfc3339("2017-09-21T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let crafting_reset = next_crafting_reset(now);
+
+        assert_eq!(crafting_reset,
+                   expected_reset,
+                   "Expected next crafting reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   crafting_reset);
+    }
+
+    #[test]
+    fn next_crafting_reset_after_reset_time_on_thursday() {
+        let now = DateTime::parse_from_rfc3339("2017-09-28T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset = DateTime::parse_from_rfc3339("2017-10-05T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let crafting_reset = next_crafting_reset(now);
+
+        assert_eq!(crafting_reset,
+                   expected_reset,
+                   "Expected next crafting reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   crafting_reset);
+    }
+
+    #[test]
+    fn next_crafting_reset_on_wednesday() {
+        let now = DateTime::parse_from_rfc3339("2017-09-20T06:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset = DateTime::parse_from_rfc3339("2017-09-21T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let crafting_reset = next_crafting_reset(now);
+
+        assert_eq!(crafting_reset,
+                   expected_reset,
+                   "Expected next crafting reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   crafting_reset);
+    }
+
+    #[test]
+    fn next_crafting_reset_on_friday() {
+        let now = DateTime::parse_from_rfc3339("2017-09-22T06:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expected_reset = DateTime::parse_from_rfc3339("2017-09-28T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let crafting_reset = next_crafting_reset(now);
+
+        assert_eq!(crafting_reset,
+                   expected_reset,
+                   "Expected next crafting reset from {:?} to be at {:?}. Got: {:?}",
+                   now,
+                   expected_reset,
+                   crafting_reset);
+    }
+
+    #[test]
+    fn until_string_with_one_week() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-10-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "1 week";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_multiple_weeks() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-10-08T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "2 weeks";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_one_day() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-09-25T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "1 day";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_multiple_days() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-09-26T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "2 days";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_one_hour() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-09-24T01:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "1 hour";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_multiple_hours() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-09-24T02:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "2 hours";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_one_minute() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-09-24T00:01:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "1 minute";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_multiple_minutes() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-09-24T00:02:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "2 minutes";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_multiple_components() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-10-09T15:02:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "2 weeks 1 day 15 hours 2 minutes";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_multiple_components_with_gap() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-10-09T00:02:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "2 weeks 1 day 2 minutes";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn until_string_with_less_than_a_minute() {
+        let now = DateTime::parse_from_rfc3339("2017-09-24T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let event = DateTime::parse_from_rfc3339("2017-09-24T00:00:30Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = event.signed_duration_since(now);
+        let expected = "less than a minute";
+
+        assert_eq!(until_string(duration), expected);
+    }
+
+    #[test]
+    fn parse_event_json_with_info() {
+        let json_to_parse = r#"{"timers":[{"name":"<a href=\"http://na.finalfantasyxiv.com/mount_campaign_2017/\">Fly the Falcon Mount Campaign</a>","type":"campaign","start":14988924E5,"end":150684114E4,"info":"Players who purchase a total of 90 days of subscription time during this time period will receive a Falcon mount."}]}"#;
+        let expected = FFXIVTimers {
+            events: vec![
+                FFXIVEvent {
+                    name_html: "<a href=\"http://na.finalfantasyxiv.com/mount_campaign_2017/\">Fly the Falcon Mount Campaign</a>".to_string(),
+                    kind: "campaign".to_string(),
+                    start: DateTime::parse_from_rfc3339("2017-07-01T07:00:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    end: DateTime::parse_from_rfc3339("2017-10-01T06:59:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    info: Some("Players who purchase a total of 90 days of subscription time during this time period will receive a Falcon mount.".to_string())
+                }
+            ]
+        };
+
+        let result: FFXIVTimers = parse_event_json(&json_to_parse.to_string().into_bytes()).unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_event_json_without_info() {
+        let json_to_parse = r#"{"timers":[{"name":"<a href=\"http://na.finalfantasyxiv.com/lodestone/special/2017/The_Rising/\">The Rising</a>","type":"event rising","start":15037596E5,"end":150540114E4,"showDuration":true}]}"#;
+        let expected = FFXIVTimers {
+            events: vec![
+                FFXIVEvent {
+                    name_html: "<a href=\"http://na.finalfantasyxiv.com/lodestone/special/2017/The_Rising/\">The Rising</a>".to_string(),
+                    kind: "event rising".to_string(),
+                    start: DateTime::parse_from_rfc3339("2017-08-26T15:00:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    end: DateTime::parse_from_rfc3339("2017-09-14T14:59:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    info: None
+                }
+            ]
+        };
+
+        let result: FFXIVTimers = parse_event_json(&json_to_parse.to_string().into_bytes()).unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_event_json_with_multiple_events() {
+        let json_to_parse = r#"{"timers":[{"name":"<a href=\"http://na.finalfantasyxiv.com/mount_campaign_2017/\">Fly the Falcon Mount Campaign</a>","type":"campaign","start":14988924E5,"end":150684114E4,"info":"Players who purchase a total of 90 days of subscription time during this time period will receive a Falcon mount."},{"name":"<a href=\"http://na.finalfantasyxiv.com/lodestone/special/2017/The_Rising/\">The Rising</a>","type":"event rising","start":15037596E5,"end":150540114E4,"showDuration":true},{"name":"<a href=\"https://na.finalfantasyxiv.com/lodestone/special/2017/youkai-watch/\">Yo-kai Watch</a>","type":"event yokai-watch","start":15044256E5,"end":150954834E4,"showDuration":true},{"name":"<a href=\"http://na.finalfantasyxiv.com/lodestone/news/detail/5c652e0bf15a5028c3d2762c78d9ed094c475472\">All Worlds Maintenance (Sep. 14)</a>","type":"maintenance","start":15054552E5,"end":1505466E6}]}"#;
+        let expected = FFXIVTimers {
+            events: vec![
+                FFXIVEvent {
+                    name_html: "<a href=\"http://na.finalfantasyxiv.com/mount_campaign_2017/\">Fly the Falcon Mount Campaign</a>".to_string(),
+                    kind: "campaign".to_string(),
+                    start: DateTime::parse_from_rfc3339("2017-07-01T07:00:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    end: DateTime::parse_from_rfc3339("2017-10-01T06:59:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    info: Some("Players who purchase a total of 90 days of subscription time during this time period will receive a Falcon mount.".to_string())
+                },
+                FFXIVEvent {
+                    name_html: "<a href=\"http://na.finalfantasyxiv.com/lodestone/special/2017/The_Rising/\">The Rising</a>".to_string(),
+                    kind: "event rising".to_string(),
+                    start: DateTime::parse_from_rfc3339("2017-08-26T15:00:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    end: DateTime::parse_from_rfc3339("2017-09-14T14:59:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    info: None
+                },
+                FFXIVEvent {
+                    name_html: "<a href=\"https://na.finalfantasyxiv.com/lodestone/special/2017/youkai-watch/\">Yo-kai Watch</a>".to_string(),
+                    kind: "event yokai-watch".to_string(),
+                    start: DateTime::parse_from_rfc3339("2017-09-03T08:00:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    end: DateTime::parse_from_rfc3339("2017-11-01T14:59:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    info: None
+                },
+                FFXIVEvent {
+                    name_html: "<a href=\"http://na.finalfantasyxiv.com/lodestone/news/detail/5c652e0bf15a5028c3d2762c78d9ed094c475472\">All Worlds Maintenance (Sep. 14)</a>".to_string(),
+                    kind: "maintenance".to_string(),
+                    start: DateTime::parse_from_rfc3339("2017-09-15T06:00:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    end: DateTime::parse_from_rfc3339("2017-09-15T09:00:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    info: None
+                }
+            ]
+        };
+
+        let result: FFXIVTimers = parse_event_json(&json_to_parse.to_string().into_bytes()).unwrap();
+
+        assert_eq!(result, expected);
+    }
 }

--- a/src/commands/misc.rs
+++ b/src/commands/misc.rs
@@ -44,19 +44,19 @@ command!(eight_ball(_ctx, msg) {
 });
 
 command!(dice(_ctx, msg, arg) {
-    let roll = arg.single::<String>().unwrap();
-    let re = Regex::new("^(?P<quantity>\\d+)?d(?P<sides>\\d+)$").unwrap();
+    let roll = arg.single::<String>().expect("Couldn't parse arg as a String");
+    let re = Regex::new("^(?P<quantity>\\d+)?d(?P<sides>\\d+)$").expect("Couldn't create regex");
     let caps = match re.captures(&roll) {
         Some(c) => c,
         None => return Ok(()),
     };
 
     let quantity = match caps.name("quantity") {
-        Some(m) => m.as_str().parse::<u64>().unwrap(),
+        Some(m) => m.as_str().parse::<u64>().expect("Couldn't parse quantity of dice"),
         None => 1,
     };
 
-    let sides = caps.name("sides").unwrap().as_str().parse::<u64>().unwrap();
+    let sides = caps.name("sides").unwrap().as_str().parse::<u64>().expect("Couldn't parse how many sides per die");
 
     let mut total = 0;
 

--- a/src/commands/misc.rs
+++ b/src/commands/misc.rs
@@ -44,7 +44,11 @@ command!(eight_ball(_ctx, msg) {
 });
 
 command!(dice(_ctx, msg, arg) {
-    let roll = arg.single::<String>().expect("Couldn't parse arg as a String");
+    let roll = match arg.single::<String>() {
+        Ok(r) => r,
+        Err(_)=> "1d1000".to_string(),
+    };
+
     let re = Regex::new("^(?P<quantity>\\d+)?d(?P<sides>\\d+)$").expect("Couldn't create regex");
     let caps = match re.captures(&roll) {
         Some(c) => c,

--- a/src/commands/misc.rs
+++ b/src/commands/misc.rs
@@ -1,66 +1,68 @@
+use discord::Discord;
+use discord::model::Message;
 use rand;
 use rand::Rng;
 use regex::Regex;
+use framework::args::Args;
 
-command!(latency(ctx, msg) {
-    let latency = ctx.shard.lock()
-                           .latency()
-                           .map_or_else(|| "N/A".to_owned(), |s| {
-                               format!("{}.{}s", s.as_secs(), s.subsec_nanos())
-                           });
+pub fn ping(bot: &Discord, msg: &Message, _args: Args) {
+    let _ = bot.send_message(msg.channel_id, "Pong!", "", false);
+}
 
-    let _ = msg.channel_id.say(latency);
-});
+pub fn eight_ball(bot: &Discord, msg: &Message, _args: Args) {
+    let responses = ["It is certain",
+                     "It is decidedly so",
+                     "Without a doubt",
+                     "Yes definitely",
+                     "You may rely on it",
+                     "As I see it, yes",
+                     "Most likely",
+                     "Outlook good",
+                     "Yes",
+                     "Signs point to yes",
+                     "Reply hazy try again",
+                     "Ask again later",
+                     "Better not tell you now",
+                     "Cannot predict now",
+                     "Concentrate and ask again",
+                     "Don't count on it",
+                     "My reply is no",
+                     "My sources say no",
+                     "Outlook not so good",
+                     "Very doubtful"];
 
-command!(ping(_ctx, msg) {
-    let _ = msg.channel_id.say("Pong!");
-});
+    let _ = bot.send_message(msg.channel_id,
+                             rand::thread_rng().choose(&responses).unwrap(),
+                             "",
+                             false);
+}
 
-command!(eight_ball(_ctx, msg) {
-    let responses = [
-        "It is certain",
-        "It is decidedly so",
-        "Without a doubt",
-        "Yes definitely",
-        "You may rely on it",
-        "As I see it, yes",
-        "Most likely",
-        "Outlook good",
-        "Yes",
-        "Signs point to yes",
-        "Reply hazy try again",
-        "Ask again later",
-        "Better not tell you now",
-        "Cannot predict now",
-        "Concentrate and ask again",
-        "Don't count on it",
-        "My reply is no",
-        "My sources say no",
-        "Outlook not so good",
-        "Very doubtful"
-    ];
-
-    let _ = msg.channel_id.say(rand::thread_rng().choose(&responses).unwrap());
-});
-
-command!(dice(_ctx, msg, arg) {
-    let roll = match arg.single::<String>() {
+pub fn roll(bot: &Discord, msg: &Message, mut args: Args) {
+    let roll = match args.single::<String>() {
         Ok(r) => r,
-        Err(_)=> "1d1000".to_string(),
+        Err(_) => "1d1000".to_string(),
     };
 
     let re = Regex::new("^(?P<quantity>\\d+)?d(?P<sides>\\d+)$").expect("Couldn't create regex");
     let caps = match re.captures(&roll) {
         Some(c) => c,
-        None => return Ok(()),
+        None => return,
     };
 
     let quantity = match caps.name("quantity") {
-        Some(m) => m.as_str().parse::<u64>().expect("Couldn't parse quantity of dice"),
+        Some(m) => {
+            m.as_str()
+                .parse::<u64>()
+                .expect("Couldn't parse quantity of dice")
+        }
         None => 1,
     };
 
-    let sides = caps.name("sides").unwrap().as_str().parse::<u64>().expect("Couldn't parse how many sides per die");
+    let sides = caps.name("sides")
+        .unwrap()
+        .as_str()
+        .parse::<u64>()
+        .expect("Couldn't parse how many sides per die");
 
     let mut total = 0;
 
@@ -68,5 +70,11 @@ command!(dice(_ctx, msg, arg) {
         total += rand::thread_rng().gen_range(0, sides) + 1;
     }
 
-    let _ = msg.reply(&format!("Rolled {} and got {}", roll, total));
-});
+    let _ = bot.send_message(msg.channel_id,
+                             &format!("{}: Rolled {} and got {}",
+                                     msg.author.mention(),
+                                     roll,
+                                     total),
+                             "",
+                             false);
+}

--- a/src/framework/args.rs
+++ b/src/framework/args.rs
@@ -1,0 +1,94 @@
+use nom::{self, ErrorKind, IResult, Needed};
+use std::fmt;
+use std::str::{self, FromStr};
+use std::error::Error as StdError;
+use util::arg_parser;
+
+#[derive(Debug)]
+pub enum Error<E: StdError> {
+    Parse(E),
+    Empty,
+    ArgParse,
+}
+
+impl<E: StdError> From<E> for Error<E> {
+    fn from(e: E) -> Self {
+        Error::Parse(e)
+    }
+}
+
+impl<E: StdError> StdError for Error<E> {
+    fn description(&self) -> &str {
+        match self {
+            &Error::ArgParse => "Error parsing argument string",
+            &Error::Parse(ref e) => e.description(),
+            &Error::Empty => "No remaining unparsed arguments",
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match self {
+            &Error::Parse(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl<E: StdError> fmt::Display for Error<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &Error::ArgParse => write!(f, "Error parsing argument string"),
+            &Error::Parse(ref e) => write!(f, "Parse error: {}", e),
+            &Error::Empty => write!(f, "No remaining unparsed arguments"),
+        }
+    }
+}
+
+type Result<T, E> = ::std::result::Result<T, Error<E>>;
+
+#[derive(Debug)]
+pub struct Args {
+    unparsed: String,
+}
+
+impl Args {
+    pub fn new(arg_str: &str) -> Args {
+        Args { unparsed: arg_str.to_string() }
+    }
+
+    pub fn single<T: FromStr>(&mut self) -> Result<T, T::Err>
+        where T::Err: StdError
+    {
+        if self.unparsed.is_empty() {
+            return Err(Error::Empty);
+        }
+
+        let to_parse = self.unparsed.clone();
+        match arg_parser::single_arg(to_parse.as_bytes()) {
+            IResult::Done(rest, arg_str) => {
+                let result = arg_str.parse::<T>()?;
+                self.unparsed = str::from_utf8(rest).unwrap().to_string();
+                Ok(result)
+            }
+            _ => Err(Error::ArgParse),
+        }
+    }
+
+    pub fn single_quoted<T: FromStr>(&mut self) -> Result<T, T::Err>
+        where T::Err: StdError
+    {
+        if self.unparsed.is_empty() {
+            return Err(Error::Empty);
+        }
+
+        let to_parse = self.unparsed.clone();
+        match arg_parser::single_quoted_arg(to_parse.as_bytes()) {
+            IResult::Done(rest, arg_str) => {
+                let result = arg_str.parse::<T>()?;
+                self.unparsed = str::from_utf8(rest).unwrap().to_string();
+                Ok(result)
+            }
+            _ => Err(Error::ArgParse),
+        }
+    }
+}

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -1,0 +1,1 @@
+pub mod args;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 extern crate chrono;
+extern crate discord;
 extern crate dotenv;
+#[macro_use]
+extern crate nom;
 extern crate rand;
 extern crate reqwest;
 extern crate regex;
@@ -8,62 +11,137 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
-#[macro_use]
-extern crate serenity;
 
 mod commands;
+mod util;
+mod framework;
 
+use discord::Discord;
+use discord::model::{Event, Message};
 use dotenv::dotenv;
-use serenity::prelude::*;
-use serenity::model::*;
-use serenity::framework::StandardFramework;
-use serenity::framework::standard::help_commands;
-
+use framework::args::Args;
 use std::env;
 
-struct Handler;
-impl EventHandler for Handler {
-    fn on_ready(&self, _: Context, ready: Ready) {
-        println!("{} is connected!", ready.user.name);
+type Exec = Fn(&Discord, &Message, Args);
+
+struct BotCommand {
+    command: String,
+    description: Option<String>,
+    exec: Box<Exec>,
+}
+
+impl BotCommand {
+    fn command_matches(&self, message: &str) -> bool {
+        message.starts_with(&self.command)
     }
 }
+
+macro_rules! command (
+    ($cmd_name:expr, $fn_name:path) => (
+        {
+            BotCommand {
+                command: format!("{}", &$cmd_name).to_lowercase(),
+                description: None,
+                exec: Box::new($fn_name),
+            }
+        }
+    );
+    ($cmd_name:expr, $desc:expr, $fn_name:path) => (
+        {
+            BotCommand {
+                command: format!("{}", &$cmd_name).to_lowercase(),
+                description: Some($desc.to_string()),
+                exec: Box::new($fn_name),
+            }
+        }
+    );
+);
 
 fn main() {
     dotenv().ok();
 
-    let mut client = Client::new(&env::var("DISCORD_TOKEN").expect("Could not read DISCORD_TOKEN environment variable"), Handler);
+    let bot_command_prefix = env::var("TECHNOBOT_PREFIX").unwrap_or("!".to_string());
 
-    client.with_framework(StandardFramework::new()
-                          .configure(|c| c
-                                     .prefix(&env::var("TECHNOBOT_PREFIX")
-                                             .unwrap_or("~".to_string()))
-                                     .case_insensitivity(true)
-                          )
-                          .group("Final Fantasy XIV", |g| g
-                                 .prefix("ffxiv")
-                                 .command("resets", |c| c
-                                          .desc("Show how long until the daily/weekly/crafting resets in FF XIV")
-                                          .exec(commands::ffxiv::resets)
-                                 )
-                                 .command("events", |c| c
-                                          .desc("List known events in FF XIV")
-                                          .exec(commands::ffxiv::events)
-                                 )
-                          )
-                          .command("ping", |c| c.exec(commands::misc::ping))
-                          .command("latency", |c| c.exec(commands::misc::latency))
-                          .command("8-ball", |c| c
-                                   .desc("Ask the magic 8-ball any yes/no question")
-                                   .exec(commands::misc::eight_ball)
-                          )
-                          .command("roll", |c| c
-                                   .exec(commands::misc::dice)
-                                   .max_args(1)
-                          )
-                          .command("help", |c| c.exec_help(help_commands::with_embeds))
-    );
+    let mut commands: Vec<BotCommand> = Vec::new();
+    commands.push(command!("ping", commands::misc::ping));
+    commands.push(command!("8-ball",
+                           "Ask the magic 8-ball any yes/no question.",
+                           commands::misc::eight_ball));
+    commands.push(command!("roll", commands::misc::roll));
 
-    if let Err(why) = client.start_autosharded() {
-        println!("Client error: {:?}", why);
+    commands.push(command!("ffxiv resets",
+                           "Show how long until the daily/weekly resets in FF XIV",
+                           commands::ffxiv::resets));
+    commands.push(command!("ffxiv events",
+                           "List known events in FF XIV",
+                           commands::ffxiv::events));
+
+    let discord = match Discord::from_bot_token(&env::var("DISCORD_TOKEN").expect("Could not read DISCORD_TOKEN environment variable")) {
+        Ok(d) => d,
+        Err(e) => panic!("Unable to log in to Discord: {}", e),
+    };
+
+    let recommended_shards = match discord.suggested_shard_count() {
+        Ok(s) => s,
+        Err(e) => panic!("Could not get recommended shard count: {}", e),
+    };
+    println!("Recommended number of shards for bot: {}",
+             &recommended_shards);
+
+    let (mut connection, ready_event) = match discord.connect() {
+        Ok((mut c, r)) => (c, r),
+        Err(e) => panic!("Unable to connect to Discord: {}", e),
+    };
+
+    println!("Connected as: {}", &ready_event.user.username);
+    match &ready_event.shard {
+        &Some(s) => println!("Connected as shard: {:?}", s),
+        &None => println!("Not using sharding."),
+    }
+    println!("Connected servers: {}", &ready_event.servers.len());
+
+    loop {
+        match connection.recv_event() {
+            Ok(Event::MessageCreate(message)) => {
+                if message.author.id != ready_event.user.id {
+                    if message.content.starts_with(&bot_command_prefix) {
+                        let lowercase_message = message.content[bot_command_prefix.len()..]
+                            .to_lowercase();
+                        for cmd in &commands {
+                            if cmd.command_matches(&lowercase_message) {
+                                (cmd.exec)(&discord,
+                                           &message,
+                                           Args::new(message.content[bot_command_prefix.len() +
+                                                     cmd.command.len()..]
+                                                             .trim()));
+                                break;
+                            }
+                        }
+                    }
+
+                    if message.content == format!("{}help", &bot_command_prefix) {
+                        for cmd in &commands {
+                            let cmd_help = match &cmd.description {
+                                &Some(ref d) => {
+                                    format!("{}{} -> {}", &bot_command_prefix, &cmd.command, d)
+                                }
+                                &None => format!("{}{}", &bot_command_prefix, &cmd.command),
+                            };
+                            let _ = discord.send_message(message.channel_id, &cmd_help, "", false);
+                        }
+                    }
+                    if message.content == format!("{}quit", &bot_command_prefix) {
+                        println!("Quitting.");
+                        break;
+                    }
+                }
+            }
+            Ok(_) => {}
+            Err(discord::Error::Closed(code, body)) => {
+                println!("Gateway closed on us with code {:?}: {}", code, body);
+                break;
+            }
+            Err(err) => println!("Receive error: {:?}", err),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate chrono;
+extern crate dotenv;
 extern crate futures;
 extern crate hyper;
 extern crate rand;
@@ -14,6 +15,7 @@ extern crate tokio_core;
 
 mod commands;
 
+use dotenv::dotenv;
 use serenity::prelude::*;
 use serenity::model::*;
 use serenity::framework::StandardFramework;
@@ -29,7 +31,9 @@ impl EventHandler for Handler {
 }
 
 fn main() {
-    let mut client = Client::new(&env::var("DISCORD_TOKEN").unwrap(), Handler);
+    dotenv().ok();
+
+    let mut client = Client::new(&env::var("DISCORD_TOKEN").expect("Could not read DISCORD_TOKEN environment variable"), Handler);
 
     client.with_framework(StandardFramework::new()
                           .configure(|c| c

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 extern crate chrono;
 extern crate dotenv;
-extern crate futures;
-extern crate hyper;
 extern crate rand;
+extern crate reqwest;
 extern crate regex;
 extern crate scraper;
 extern crate serde;
@@ -11,7 +10,6 @@ extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
 extern crate serenity;
-extern crate tokio_core;
 
 mod commands;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
                           )
                           .command("roll", |c| c
                                    .exec(commands::misc::dice)
-                                   .num_args(1)
+                                   .max_args(1)
                           )
                           .command("help", |c| c.exec_help(help_commands::with_embeds))
     );

--- a/src/util/arg_parser.rs
+++ b/src/util/arg_parser.rs
@@ -1,0 +1,135 @@
+use nom::{AsBytes, AsChar, ErrorKind, IResult, InputIter, InputLength, is_space, Needed, Slice,
+          space};
+
+use std::ops::{Range, RangeFrom, RangeTo};
+use std::str;
+use std::string::String;
+
+fn non_quote_special<T>(input: T) -> IResult<T, T>
+    where T: Slice<Range<usize>> + Slice<RangeFrom<usize>> + Slice<RangeTo<usize>>,
+          T: InputIter + InputLength,
+          <T as InputIter>::Item: AsChar
+{
+    let input_length = input.input_len();
+    if input_length == 0 {
+        return IResult::Incomplete(Needed::Unknown);
+    }
+
+    for (idx, item) in input.iter_indices() {
+        let item_char = item.as_char();
+        if item_char == '"' || item_char == '\\' {
+            if idx == 0 {
+                return IResult::Error(error_position!(ErrorKind::IsNot, input));
+            } else {
+                return IResult::Done(input.slice(idx..), input.slice(0..idx));
+            }
+        }
+    }
+    IResult::Done(input.slice(input_length..), input)
+}
+
+fn single<'a>(input: &'a [u8]) -> IResult<&'a [u8], &'a str> {
+    if input.input_len() == 0 {
+        return IResult::Incomplete(Needed::Unknown);
+    }
+
+    map_res!(input,
+             do_parse!(
+        arg: take_till!(is_space) >>
+        (arg)
+    ),
+             str::from_utf8)
+}
+
+fn single_string<'a>(input: &'a [u8]) -> IResult<&'a [u8], String> {
+    match single(input) {
+        IResult::Done(r, s) => IResult::Done(r, s.to_string()),
+        IResult::Error(e) => IResult::Error(e),
+        IResult::Incomplete(i) => IResult::Incomplete(i),
+    }
+}
+
+pub fn single_arg<'a>(input: &'a [u8]) -> IResult<&'a [u8], &'a str> {
+    if input.input_len() == 0 {
+        return IResult::Incomplete(Needed::Unknown);
+    }
+
+    do_parse!(input,
+        arg: call!(single) >>
+        alt!(eof!() | space) >>
+        (arg)
+    )
+}
+
+
+fn quoted<'a>(input: &'a [u8]) -> IResult<&'a [u8], String> {
+    map_res!(input,
+             do_parse!(
+        arg: delimited!(
+            char!('"'),
+            escaped_transform!(
+                call!(non_quote_special),
+                '\\',
+                alt!(
+                    tag!("\\") => { |_| &b"\\"[..] } |
+                    tag!("\"") => { |_| &b"\""[..] }
+                )),
+            char!('"')) >>
+        (arg)
+    ),
+             String::from_utf8)
+}
+
+pub fn single_quoted_arg<'a>(input: &'a [u8]) -> IResult<&'a [u8], String> {
+    do_parse!(input,
+        arg: alt!(call!(quoted) | call!(single_string)) >>
+        alt!(eof!() | space) >>
+        (arg)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_arg() {
+        assert_eq!(single_arg("".as_bytes()),
+                   IResult::Incomplete(Needed::Unknown));
+        assert_eq!(single_arg("single".as_bytes()),
+                   IResult::Done("".as_bytes(), "single"));
+        assert_eq!(single_arg("one two".as_bytes()),
+                   IResult::Done("two".as_bytes(), "one"));
+        assert_eq!(single_arg("\"one two\"".as_bytes()),
+                   IResult::Done("two\"".as_bytes(), "\"one"));
+    }
+
+    #[test]
+    fn test_single_quoted_arg() {
+        assert_eq!(single_quoted_arg("".as_bytes()),
+                   IResult::Incomplete(Needed::Size(1)));
+        assert_eq!(single_quoted_arg("single".as_bytes()),
+                   IResult::Done("".as_bytes(), "single".to_string()));
+        assert_eq!(single_quoted_arg("one two".as_bytes()),
+                   IResult::Done("two".as_bytes(), "one".to_string()));
+
+        assert_eq!(single_quoted_arg("\"quoted arg\" with more".as_bytes()),
+                   IResult::Done("with more".as_bytes(), "quoted arg".to_string()));
+        assert_eq!(single_quoted_arg("\"quoted with \\\" escaped\" more".as_bytes()),
+                   IResult::Done("more".as_bytes(), "quoted with \" escaped".to_string()));
+        assert_eq!(single_quoted_arg("\"quote does not end".as_bytes()),
+                   IResult::Incomplete(Needed::Size(20)));
+    }
+
+    #[test]
+    fn test_quoted() {
+        assert_eq!(quoted(&b""[..]), IResult::Incomplete(Needed::Size(1)));
+
+        assert_eq!(quoted(&b"\"quoted thing\" lkj lkj lkj lkj lkj lkj "[..]),
+                   IResult::Done(&b" lkj lkj lkj lkj lkj lkj "[..],
+                                 "quoted thing".to_string()));
+
+        assert_eq!(quoted(&b"no quotes here"[..]),
+                   IResult::Error(error_position!(ErrorKind::Char, "no quotes here".as_bytes())));
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod arg_parser;


### PR DESCRIPTION
The Serenity crate has some extremely bad behavior centered around argument parsing for commands, and doesn't readily support things like watching all messages for karma mentions (Eg: `thing++` or `thing--`). The Discord library doesn't provide nearly as many helpers, but is much more flexible, and has zero opinion on how command argument parsing should be done.
